### PR TITLE
Fixing armor values

### DIFF
--- a/mech/hyadesrim/B/mechdef_kintaro_KTO-19b.json
+++ b/mech/hyadesrim/B/mechdef_kintaro_KTO-19b.json
@@ -55,28 +55,28 @@
         {
             "DamageLevel": "Functional",
             "Location": "LeftTorso",
-            "CurrentArmor": 140,
+            "CurrentArmor": 130,
             "CurrentRearArmor": 30,
             "CurrentInternalStructure": 65,
-            "AssignedArmor": 140,
+            "AssignedArmor": 130,
             "AssignedRearArmor": 30
         },
         {
             "DamageLevel": "Functional",
             "Location": "CenterTorso",
-            "CurrentArmor": 135,
+            "CurrentArmor": 155,
             "CurrentRearArmor": 40,
             "CurrentInternalStructure": 90,
-            "AssignedArmor": 135,
+            "AssignedArmor": 155,
             "AssignedRearArmor": 40
         },
         {
             "DamageLevel": "Functional",
             "Location": "RightTorso",
-            "CurrentArmor": 140,
+            "CurrentArmor": 130,
             "CurrentRearArmor": 30,
             "CurrentInternalStructure": 65,
-            "AssignedArmor": 140,
+            "AssignedArmor": 130,
             "AssignedRearArmor": 30
         },
         {


### PR DESCRIPTION
I loaded up the KTO-19b after 1001 BattleMechs to customize it, and noticed that the torsos had more armor than is allowed by the rules.  I moved the excess armor points to the CT.