### PR TITLE
MultipleProblems

### DIFF
--- a/contracts/hyadesrim/story/puttingOutAFire_3a_threeWayBattle.json
+++ b/contracts/hyadesrim/story/puttingOutAFire_3a_threeWayBattle.json
@@ -2939,7 +2939,7 @@
             "overrideDialogueBucketId" : "",
             "dialogueContent" : [
                 {
-                    "words" : "PLACHEHOLDER (Hostile to All Primary). In bound hostile Dropship detected, drop zone marked.",
+                    "words" : "Inbound hostile Dropship detected.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,


### PR DESCRIPTION
The Dialogue_Interrupt_DropWarning_HostileToAll_Primary and Dialogue_Interrupt_DropWarning_HostileToAll_Secondary interrupts both happen.  It would look cleaner if only the Secondary text appeared.

Also, the initial lace of 4 custom Wolverines shows up as Kurita units.  It feels like those should be Jinxie units.  Sumire even says that they are likely the backup singers when the main Jinxie force arrives.

Then again, maybe they're supposed to be ISF because the Jinxie units that arrive as reinforcements attack them, but then if so, they should be Combine mechs, not custom Wolverines.  Either way, something isn't right.