### PR TITLE
Another typo and a base game portrait mismatch

### DIFF
--- a/contracts/hyadesrim/story/paradiseCity_2_threeWayBattle.json
+++ b/contracts/hyadesrim/story/paradiseCity_2_threeWayBattle.json
@@ -2478,7 +2478,7 @@
                         "b" : 1,
                         "a" : 1
                     },
-                    "selectedCastDefId" : "castDef_MagistracyDefault",
+                    "selectedCastDefId" : "castDef_MagistracyDefaultCommander",
                     "emote" : "Default",
                     "audioName" : "NONE",
                     "cameraFocusGuid" : "c76a6d7f-2e68-46f8-b2b1-797b5c46462c",
@@ -2907,7 +2907,7 @@
                     "revealRadius" : -1
                 },
                 {
-                    "words" : "Should be easy, otherwise try not no panic and remember I'll be behind you, all the time.",
+                    "words" : "Should be easy, otherwise try not to panic and remember I'll be behind you, all the time.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,


### PR DESCRIPTION
Missed this one before.

Also!  castDef_MagistracyDefault points to sprites/Portraits/guiTxrPort_Marik_default_utr.png instead of guiTxrPort_SE03_CanopianMarine_def_utr so use castDef_MagistracyDefaultCommander instead

Lastly, the big reinforcement lance at the end is still full of Plasma units, not MAF units