### PR TITLE
Typos

### DIFF
--- a/contracts/hyadesrim/story/paradiseCity_2_threeWayBattle.json
+++ b/contracts/hyadesrim/story/paradiseCity_2_threeWayBattle.json
@@ -1528,7 +1528,7 @@
             "overrideDialogueBucketId" : "",
             "dialogueContent" : [
                 {
-                    "words" : "Baumman, what's the plan?",
+                    "words" : "Baumann, what's the plan?",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,
@@ -1740,7 +1740,7 @@
                     "revealRadius" : -1
                 },
                 {
-                    "words" : "You better help the Bounty Hunter or this deal is off",
+                    "words" : "You better help the Bounty Hunter or this deal is off!",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,


### PR DESCRIPTION
Minor typos.  This version of the contract worked very well!  The only minor problem was that the MAF double lance deployment all braced during their first turn, but I've seen that happen sometimes with reinforcement lances.