### PR TITLE
theMagistrate_1_assassinate changes

### DIFF
--- a/contracts/hyadesrim/story/theMagistrate_1_assassinate.json
+++ b/contracts/hyadesrim/story/theMagistrate_1_assassinate.json
@@ -11,8 +11,8 @@
     "missionSuccessStatementOverride" : null,
     "badFaithStatementOverride" : null,
     "goodFaithStatementOverride" : null,
-    "shortDescription" : "Senator Quintus Publius's family <i>villa</i> is located in the outskirts of the capital Nova Roma and despite being a large farm estate, it is also heavily guarded due to their patrician status. So we'll need to create a feint first for the Marians to respond before we move to take down the senator.",
-    "longDescription" : "Taking down a couple of their lances should call their attention.",
+    "shortDescription" : "Senator Quintus Publius's family <i>villa</i> is located in the outskirts of the capital Nova Roma and despite being a large farm estate, it is also heavily guarded due to their patrician status. We'll need to create a feint first for the Marians to respond to before we move to take down the senator.",
+    "longDescription" : "Taking down a couple of lances should get their attention.",
     "salvagePotential" : 8,
     "requirementList" : [],
     "OnContractSuccessResults" : [],
@@ -292,7 +292,7 @@
                     "revealRadius" : -1
                 },
                 {
-                    "words" : "If they bite the feint, they'll drop reinforcements but destroying them is secondary to us.",
+                    "words" : "If they bite the feint, they'll drop reinforcements but destroying them is secondary for us.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,


### PR DESCRIPTION
Some typos but also the ending dialogue replays twice.  I don't know how to fix that.
  "We took out the century and the centurion and they've responded to it."
  "We are going uprank in our target list by moving to magistrate."
  "Yes, Sumire. We should be able to break into Senator's Publius <i>villa</i> now."
  "We took out the century and the centurion and they've responded to it."
  "We are going uprank in our target list by moving to magistrate."
  "Yes, Sumire. We should be able to break into Senator's Publius <i>villa</i> now."