### PR TITLE
theMagistrate_3a_battle typos

### DIFF
--- a/contracts/hyadesrim/story/theMagistrate_3a_battle.json
+++ b/contracts/hyadesrim/story/theMagistrate_3a_battle.json
@@ -11,7 +11,7 @@
     "missionSuccessStatementOverride" : null,
     "badFaithStatementOverride" : null,
     "goodFaithStatementOverride" : null,
-    "shortDescription" : "I've given to your pilot the contact inside the ATC so you can conduct whatever business you have. As for the Legatus, he has been coordinating military patrols outside Nova Roma, so it should be a straight forward affair to dispose of him.",
+    "shortDescription" : "I've given your pilot the contact inside the ATC so you can conduct whatever business you have. As for the Legatus, he has been coordinating military patrols outside Nova Roma, so it should be a straight forward affair to dispose of him.",
     "longDescription" : "Not much to say, Commander. Shoot to kill.",
     "salvagePotential" : 8,
     "requirementList" : [],
@@ -150,7 +150,7 @@
                     "revealRadius" : -1
                 },
                 {
-                    "words" : "Something is no right here. Proceed with caution, Commander.",
+                    "words" : "Something is not right here. Proceed with caution, Commander.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,


### PR DESCRIPTION
Also, the text in the mission mentioned seeing only 4 mechs instead of 5, but the first opposition unit only had 3.  The reinforcements had 4.

And also, the narrative in the .json about being warned by his nephew never appeared in the mission.