### PR TITLE
darkForest_2_threeWayBattle Typo

### DIFF
--- a/contracts/hyadesrim/story/darkForest_2_threeWayBattle.json
+++ b/contracts/hyadesrim/story/darkForest_2_threeWayBattle.json
@@ -12,7 +12,7 @@
     "badFaithStatementOverride" : "",
     "goodFaithStatementOverride" : "",
     "shortDescription" : "Our rescue team is locating any ComStar survivors but we have detected a second lance several kilometers away. We need to secure the area in case we're dealing with more pirates.",
-    "longDescription" : "And then we might starting discovering what is taking place here exactly.",
+    "longDescription" : "And then we might start discovering what exactly is taking place here.",
     "salvagePotential" : 12,
     "requirementList" : [],
     "OnContractSuccessResults" : [],
@@ -1688,7 +1688,7 @@
                     "revealRadius" : -1
                 },
                 {
-                    "words" : "Assertive way, it seems as Yang has said. I'll be ready to pick you up at this location.",
+                    "words" : "Assertive way it is, like Yang has said. I'll be ready to pick you up at this location.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,
@@ -2771,7 +2771,7 @@
             "overrideDialogueBucketId" : "",
             "dialogueContent" : [
                 {
-                    "words" : "We're picking an incoming DropShip. I think the pirates came to finish the job.",
+                    "words" : "We're picking up an incoming DropShip. I think the pirates came to finish the job.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,
@@ -2796,7 +2796,7 @@
             "overrideDialogueBucketId" : "",
             "dialogueContent" : [
                 {
-                    "words" : "And second unknown track should hit here.",
+                    "words" : "And the second unknown track should hit here.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,
@@ -2837,7 +2837,7 @@
             "overrideDialogueBucketId" : "",
             "dialogueContent" : [
                 {
-                    "words" : "And second unknown track should hit here.",
+                    "words" : "And the second unknown track should hit here.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,


### PR DESCRIPTION
The Dialogue_Interrupt_AdditionalEnemyAllyForcesDropIn_Primary or Dialogue_Interrupt_HostileToAllLanceDropsIn_Secondary wording sounds like it should have happened before the Dialogue_Interrupt_DropWarning_HostileToAll_Secondary wording.  In the mission, the second track was referenced before Sumire said that the dropship track split into two.