### PR TITLE
Update Gear_HeatSink_Generic_Double.json

### DIFF
--- a/heatsinks/Gear_HeatSink_Generic_Double.json
+++ b/heatsinks/Gear_HeatSink_Generic_Double.json
@@ -27,8 +27,7 @@
     "ComponentTags" : {
         "items" : [
             "component_type_stock",
-            "component_type_lostech",
-			"BLACKLISTED"
+            "component_type_lostech"
         ],
         "tagSetSourceFile" : ""
     }


### PR DESCRIPTION
Removed BLACKLISTED to make them salvageable like the other lostech