### PR TITLE
Update comancheMoon_1_simpleBattle.json

### DIFF
--- a/contracts/hyadesrim/story/comancheMoon_1_simpleBattle.json
+++ b/contracts/hyadesrim/story/comancheMoon_1_simpleBattle.json
@@ -11,8 +11,8 @@
     "missionSuccessStatementOverride" : null,
     "badFaithStatementOverride" : null,
     "goodFaithStatementOverride" : null,
-    "shortDescription" : "We have received the confirmation codes from the Ghost Riders and they are ready to meet with you Commander. Once you establish contact with their members, it will be a matter of them visually confirming it is you. As a sign of trust, they have requested that you meet them in a lighter BattleMech since they'll all be meeting you on foot, so Yang is warming up for you the  lightest mech from the active lance.",
-    "longDescription" : "Just don't make anything foolish as getting out of your cockpit until you're all back inside the <i>Hysteria</i>, Commander.",
+    "shortDescription" : "We have received the confirmation codes from the Ghost Riders and they are ready to meet with you, Commander. Once you establish contact with their members, it will be a matter of them visually confirming it is you. As a sign of trust, they have requested that you meet them in a light BattleMech since they'll all be meeting you on foot.",
+    "longDescription" : "Just don't do anything foolish like getting out of your cockpit until you're all back inside the <i>Hysteria</i>, Commander.",
     "salvagePotential" : 0,
     "requirementList" : [],
     "OnContractSuccessResults" : [],
@@ -144,7 +144,7 @@
                     "revealRadius" : -1
                 },
                 {
-                    "words" : "It's been already half an hour here... where are the Ghost Riders?",
+                    "words" : "It's already been a half an hour here... where are the Ghost Riders?",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,
@@ -160,7 +160,7 @@
                     "revealRadius" : -1
                 },
                 {
-                    "words" : "XO, I'm picking contacts up ahead.",
+                    "words" : "XO, I'm picking up contacts ahead.",
                     "wordsColor" : {
                         "r" : 1,
                         "g" : 1,


### PR DESCRIPTION
The Mech in the first slot was not the mech that was locked into the contract.  It was the Mech in the second slot.  I'm wondering if it's a matter of referencing Mech Bay 0 instead of Mech Bay 1, but I don't see anything in this file that would alter that.